### PR TITLE
Fix typos in ImageExamples.swift

### DIFF
--- a/Sources/Pages/Examples/ImageExamples.swift
+++ b/Sources/Pages/Examples/ImageExamples.swift
@@ -105,7 +105,7 @@ struct ImageExamples: StaticPage {
             .margin(.bottom, .extraLarge)
 
         Alert {
-            Text("In case you hadn't noticed, this page uses a custom theme that plces some random content on the right-hand side,")
+            Text("In case you hadn't noticed, this page uses a custom theme that places some random content on the right-hand side.")
         }
         .role(.info)
     }


### PR DESCRIPTION
Just fixing some minor typos to get started. 
"plces" -> "places"
comma -> period