### PR TITLE
Update to the latest package version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/twostraws/Ignite.git",
       "state" : {
         "branch" : "main",
-        "revision" : "5945d270db7186695109f4effdee07d328f1821f"
+        "revision" : "a9ba647e7a0ac76b2df9f9e37358f76605aaae85"
       }
     },
     {


### PR DESCRIPTION
After cloning the repository with git clone, I encountered the following error:

```
could not find the commit 5945d270db7186695109f4effdee07d328f1821f in https://github.com/twostraws/Ignite.git
```

Therefore, I performed an Update to Latest Package Versions. I believe this will allow everyone to immediately try out the samples after cloning.