### PR TITLE
Adding `Link`s to all chapters as `DropDown`s.

### DIFF
--- a/Sources/Components/NavBar.swift
+++ b/Sources/Components/NavBar.swift
@@ -12,7 +12,6 @@ import Ignite
 struct NavBar: Component {
     func body(context: PublishingContext) -> [any PageElement] {
         NavigationBar(logo: Image("/images/logo.svg", description: "ExampleSite logo").frame(width: "min(60vw, 300px)", height: "100%")) {
-            Link("Table of Contents", target: "/")
 
             Dropdown("Key concepts") {
                 Link("Grid Layout", target: GridExamples())
@@ -41,12 +40,6 @@ struct NavBar: Component {
             }
 
             Link("Ignite on GitHub", target: "https://github.com/twostraws/Ignite")
-
-            Dropdown("@twostraws") {
-                Link("Mastodon", target: "https://mastodon.social/@twostraws")
-                Link("Twitter", target: "https://twitter.com/twostraws")
-                Link("YouTube", target: "https://youtube.com/@twostraws")
-            }
         }
         .navigationItemAlignment(.trailing)
         .navigationBarStyle(.dark)

--- a/Sources/Components/NavBar.swift
+++ b/Sources/Components/NavBar.swift
@@ -14,6 +14,32 @@ struct NavBar: Component {
         NavigationBar(logo: Image("/images/logo.svg", description: "ExampleSite logo").frame(width: "min(60vw, 300px)", height: "100%")) {
             Link("Table of Contents", target: "/")
 
+            Dropdown("Key concepts") {
+                Link("Grid Layout", target: GridExamples())
+                Link("Navigation", target: NavigationExamples())
+                Link("Content", target: ContentExamples())
+                Link("Text", target: TextExamples())
+                Link("Styling", target: StylingExamples())
+            }
+
+            Dropdown("Examples") {
+                Link("Accordions", target: AccordionExamples())
+                Link("Alerts", target: AlertExamples())
+                Link("Badges", target: BadgeExamples())
+                Link("Buttons", target: ButtonExamples())
+                Link("Cards", target: CardExamples())
+                Link("Carousels", target: CarouselExamples())
+                Link("Code", target: CodeExamples())
+                Link("Dropdowns", target: DropdownExamples())
+                Link("Embeds", target: EmbedExamples())
+                Link("Images", target: ImageExamples())
+                Link("Includes", target: IncludeExamples())
+                Link("Links", target: LinkExamples())
+                Link("Lists", target: ListExamples())
+                Link("Quotes", target: QuoteExamples())
+                Link("Tables", target: TableExamples())
+            }
+
             Link("Ignite on GitHub", target: "https://github.com/twostraws/Ignite")
 
             Dropdown("@twostraws") {


### PR DESCRIPTION
This is the `NavBar` implementation used in https://github.com/twostraws/Ignite/pull/49 highlighting the currently active link.

![Hightlight-active-page](https://github.com/twostraws/IgniteSamples/assets/25307503/f531fd36-1b29-4388-a965-006f2525ca90)
