### PR TITLE
Make sure there is some spacing around our page (similar to HWS)

### DIFF
--- a/Sources/Themes/MainTheme.swift
+++ b/Sources/Themes/MainTheme.swift
@@ -21,6 +21,7 @@ struct MyTheme: Theme {
                 IgniteFooter()
             }
             .padding(.vertical, 80)
+            .class("container")
         }
     }
 }


### PR DESCRIPTION
Currently our example site look on an iPhone as shown below: the text goes edge to edge. There is a minimal spacing missing. By adding the "container" CSS class to `MyTheme` rendering and readability improves for devices with a small screen (as shown by the second screenshot).

<img width="854" alt="Comparison before and after theme adjustment" src="https://github.com/twostraws/IgniteSamples/assets/25307503/bab14cf4-54a6-4ac2-9658-d91d00be90c5">
