### PR TITLE
Feat add global social footer example

### DIFF
--- a/Sources/Components/SocialFooter.swift
+++ b/Sources/Components/SocialFooter.swift
@@ -1,13 +1,14 @@
 //
-//  File.swift
-//
-//
-//  Created by joshua kaunert on 6/2/24.
+// NavBar.swift
+// IgniteSamples
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+// Created by joshua kaunert on 6/2/24.
 //
 import Foundation
 import Ignite
 
-/// Displays a "Social Footer", with each icon opening an external social site in a new browser tab, demonstrating how to create reusable components with builtIn icons and custom attributes.
+/// Displays a "Social Footer", with each icon opening an external social site in a new browser tab, demonstrating how to create reusable components with builtIn icons, external links and custom attributes.
 public struct SocialFooter: Component {
     public func body(context: PublishingContext) -> [any PageElement] {
         
@@ -45,4 +46,3 @@ public struct SocialFooter: Component {
         .margin(.top, .extraLarge)
     }
 }
-

--- a/Sources/Components/SocialFooter.swift
+++ b/Sources/Components/SocialFooter.swift
@@ -1,0 +1,48 @@
+//
+//  File.swift
+//
+//
+//  Created by joshua kaunert on 6/2/24.
+//
+import Foundation
+import Ignite
+
+/// Displays a "Social Footer", with each icon opening an external social site in a new browser tab, demonstrating how to create reusable components with builtIn icons and custom attributes.
+public struct SocialFooter: Component {
+    public func body(context: PublishingContext) -> [any PageElement] {
+        
+        let icons = [
+            Image(systemName: "github"),
+            Image(systemName: "twitter"),
+            Image(systemName: "youtube"),
+            Image(systemName: "mastodon"),
+        ]
+        
+        let urlStrings = [
+            "https://github.com/twostraws",
+            "https://twitter.com/twostraws",
+            "https://youtube.com/@twostraws",
+            "https://mastodon.social/@twostraws",
+        ]
+        
+        Text {
+            for (icon, urlString) in zip(icons, urlStrings) {
+                Link(icon, target: urlString)
+                    .margin(.trailing, 20)
+                    .role(.secondary)
+                    .addCustomAttribute(
+                        name: "target",
+                        value: "_blank"
+                    )
+                    .addCustomAttribute(
+                        name: "rel",
+                        value: "noopener noreferrer"
+                    )
+            }
+        }
+        .font(.title2)
+        .horizontalAlignment(.center)
+        .margin(.top, .extraLarge)
+    }
+}
+

--- a/Sources/Components/SocialFooter.swift
+++ b/Sources/Components/SocialFooter.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Ignite
 
-/// Displays a "Social Footer", with each icon opening an external social site in a new browser tab, demonstrating how to create reusable components with builtIn icons, external links and custom attributes.
+/// Displays a global "Social Footer", with each social icon linking to an external site in a new browser tab, demonstrating how to create reusable components with builtIn icons, external links and custom attributes.
 public struct SocialFooter: Component {
     public func body(context: PublishingContext) -> [any PageElement] {
         

--- a/Sources/Pages/Examples/AlertExamples.swift
+++ b/Sources/Pages/Examples/AlertExamples.swift
@@ -9,7 +9,7 @@ import Foundation
 import Ignite
 
 struct AlertExamples: StaticPage {
-    var title = "Accordions"
+    var title = "Alerts"
 
     func body(context: PublishingContext) async -> [BlockElement] {
         Text("Alerts")

--- a/Sources/Themes/MainTheme.swift
+++ b/Sources/Themes/MainTheme.swift
@@ -18,7 +18,10 @@ struct MyTheme: Theme {
 
                 page.body
 
-                IgniteFooter()
+                Group {
+                    SocialFooter()
+                    IgniteFooter()
+                }
             }
             .padding(.vertical, 80)
             .class("container")


### PR DESCRIPTION
Adds a global footer example using builtin icons and custom attributes. wasn't sure where/whether to also create a static page, but can update the PR if needed.