### PR TITLE
Map Element Discussion

### DIFF
--- a/.swiftpm/configuration/Package.resolved
+++ b/.swiftpm/configuration/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "4d42983e47a4eed1de01d3c30753d8ce8cc3a1afb20bde800976b9e4ee3fbd2d",
   "pins" : [
     {
       "identity" : "ignite",
@@ -6,7 +7,7 @@
       "location" : "https://github.com/dl-alexandre/Ignite",
       "state" : {
         "branch" : "main",
-        "revision" : "c643e9e76ba8d7dacbc980f724ce1d325faf10e5"
+        "revision" : "757caa5b456905248affbcc51ed47652c3a5b373"
       }
     },
     {
@@ -14,17 +15,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
-        "version" : "1.4.0"
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
       }
     },
     {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-cmark.git",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
       "state" : {
         "branch" : "gfm",
-        "revision" : "2c47322cb32cbed555f13bf5cbfaa488cc30a785"
+        "revision" : "fc07ab5da47975c5ef5f336acadfc02e8f706d30"
       }
     },
     {
@@ -33,9 +34,9 @@
       "location" : "https://github.com/apple/swift-markdown.git",
       "state" : {
         "branch" : "main",
-        "revision" : "365bf2d61d5fbca5cbd3b359b203ef6a69d9381f"
+        "revision" : "d21714073e0d16ba78eebdf36724863afc36871d"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Includes/annotations.html
+++ b/Includes/annotations.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<meta charset="utf-8">
+
+<style>
+#map-container {
+    height: 600px;
+}
+</style>
+
+<script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+    crossorigin async
+    data-callback="initMapKit"
+    data-libraries="map,annotations,services"
+    data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+</script>
+
+<script type="module">
+// Wait for MapKit JS to be ready to use.
+const setupMapKitJs = async() => {
+    // If MapKit JS is not yet loaded...
+    if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+        // ...await <script>'s data-callback (window.initMapKit).
+        await new Promise(resolve => { window.initMapKit = resolve });
+        // Clean up.
+        delete window.initMapKit;
+    }
+};
+
+const main = async() => {
+    await setupMapKitJs();
+
+    // Create the Map and Geocoder.
+    const map = new mapkit.Map("map-container");
+    const geocoder = new mapkit.Geocoder({ language: "en-US" });
+
+    // Create the "Event" annotation, setting properties in the constructor.
+    const event = new mapkit.Coordinate(37.7831, -122.4041);
+    const eventAnnotation = new mapkit.MarkerAnnotation(event, {
+        color: "#4eabe9",
+        title: "Event",
+        glyphText: "\u{1F37F}" // Popcorn Emoji
+    });
+
+    // Create the "Work" annotation, setting properties after construction.
+    const work = new mapkit.Coordinate(37.3349, -122.0090);
+    const workAnnotation = new mapkit.MarkerAnnotation(work);
+    workAnnotation.color = "#969696";
+    workAnnotation.title = "Work";
+    workAnnotation.subtitle = "Apple Park";
+    workAnnotation.selected = "true";
+    workAnnotation.glyphText = "\u{F8FF}"; // Apple Symbol
+
+    // Add and show both annotations on the map.
+    map.showItems([eventAnnotation, workAnnotation]);
+
+    // This contains the user-set single-tap annotation.
+    let clickAnnotation = null;
+
+    // Add or move an annotation when a user single-taps an empty space.
+    map.addEventListener("single-tap", event => {
+        if (clickAnnotation) {
+            map.removeAnnotation(clickAnnotation);
+        }
+
+        // Get the clicked coordinate and add an annotation there.
+        const point = event.pointOnPage;
+        const coordinate = map.convertPointOnPageToCoordinate(point);
+
+        clickAnnotation = new mapkit.MarkerAnnotation(coordinate, {
+            title: "Loading...",
+            color: "#c969e0"
+        });
+
+        map.addAnnotation(clickAnnotation);
+
+        // Look up the address with the Geocoder's Reverse Lookup Function.
+        geocoder.reverseLookup(coordinate, (error, data) => {
+            const first = (!error && data.results) ? data.results[0] : null;
+            clickAnnotation.title = (first && first.name) || "";
+        });
+    });
+
+};
+
+main();
+
+</script>
+
+</head>
+
+<body>
+    <div id="map-container"></div>
+</body>
+</html>

--- a/Includes/calloutAccessory.html
+++ b/Includes/calloutAccessory.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Callout Accessory Views</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, user-scalable=no">
+<style>
+
+body {
+    font-family: "Helvetica Neue", sans-serif;
+}
+
+#map-container {
+    height: 600px;
+}
+
+.left-accessory-view {
+    background-color: #4B93E0;
+    color: #FFFFFF;
+    font-size: 12px;
+}
+
+.left-accessory-view > :first-child {
+    font-size: 20px;
+}
+
+.right-accessory-view {
+    margin: 0 3px;
+    font-size: 16px;
+    text-decoration: none;
+    color: #888888;
+    outline: 0;
+}
+
+</style>
+
+
+<script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+    crossorigin async
+    data-callback="initMapKit"
+    data-libraries="map,annotations"
+    data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+</script>
+
+<script type="module">
+// Wait for MapKit JS to be ready to use.
+const setupMapKitJs = async() => {
+    // If MapKit JS is not yet loaded...
+    if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+        // ...await <script>'s data-callback (window.initMapKit).
+        await new Promise(resolve => { window.initMapKit = resolve });
+        // Clean up.
+        delete window.initMapKit;
+    }
+};
+
+const main = async() => {
+    await setupMapKitJs();
+
+    const urlWikipedia = "https://en.wikipedia.org/wiki/San_Francisco";
+
+    // Callout delegate
+    const annotationCallout = {
+        calloutLeftAccessoryForAnnotation: () => {
+            const accessoryViewLeft = document.createElement("div");
+            accessoryViewLeft.className = "left-accessory-view";
+
+            const accessoryViewLeftIcon = document.createElement("span");
+            accessoryViewLeftIcon.textContent = "\u{26C5}"; // Sun & Clouds
+            accessoryViewLeft.appendChild(accessoryViewLeftIcon);
+
+            const accessoryViewLeftText = document.createElement("div");
+            accessoryViewLeftText.textContent = "73 \u{00b0}F";
+            accessoryViewLeft.appendChild(accessoryViewLeftText);
+
+            return accessoryViewLeft;
+        },
+        calloutRightAccessoryForAnnotation: () => {
+            const accessoryViewRight = document.createElement("a");
+            accessoryViewRight.className = "right-accessory-view";
+            accessoryViewRight.href = urlWikipedia;
+            accessoryViewRight.target = "_blank";
+            accessoryViewRight.textContent = "\u{24D8}"; // (i) icon
+
+            return accessoryViewRight;
+        }
+    };
+
+    // Create an annotation.
+    const coordinate = new mapkit.Coordinate(37.7749, -122.4194);
+    const annotation = new mapkit.MarkerAnnotation(coordinate, {
+        title: "San Francisco",
+        subtitle: "California",
+        animates: true,
+        selected: true,
+        color: "#4B93E0",
+        callout: annotationCallout
+    });
+
+    // Create a map.
+    const map = new mapkit.Map("map-container", { annotations: [annotation] });
+};
+
+main();
+
+</script>
+
+</head>
+<body>
+    <div id="map-container"></div>
+</body>
+</html>

--- a/Includes/customCallout.html
+++ b/Includes/customCallout.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<meta charset="utf-8">
+
+<style>
+#map {
+    height: 600px;
+}
+
+a:link, a:visited {
+    color: #2aaef5;
+    outline: none;
+    text-decoration: none;
+}
+
+.landmark {
+    width: 250px;
+    padding: 7px 0 0 0;
+    background: rgba(247, 247, 247, 0.75);
+    border-radius: 5px;
+    box-shadow: 10px 10px 50px rgba(0, 0, 0, 0.29);
+    font-family: Helvetica, Arial, sans-serif;
+    transform-origin: 0 10px;
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+}
+
+.landmark h1 {
+    margin-top: 0;
+    padding: 5px 15px;
+    background: #2aaef5;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 16px;
+    font-weight: 300;
+}
+
+.landmark section {
+    padding: 0 15px 5px;
+    font-size: 14px;
+}
+
+.landmark section p {
+    margin: 5px 0;
+}
+
+.landmark:after {
+    content: "";
+    position: absolute;
+    top: 7px;
+    left: -13px;
+    width: 0;
+    height: 0;
+    margin-bottom: -13px;
+    border-right: 13px solid #2aaef5;
+    border-top: 13px solid rgba(0, 0, 0, 0);
+    border-bottom: 13px solid rgba(0, 0, 0, 0);
+}
+
+@-webkit-keyframes scale-and-fadein {
+    0% {
+        -webkit-transform: scale(0.2);
+        opacity: 0;
+    }
+
+    100% {
+        -webkit-transform: scale(1);
+        opacity: 1;
+    }
+}
+
+@keyframes scale-and-fadein {
+    0% {
+        transform: scale(0.2);
+        opacity: 0;
+    }
+
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+</style>
+
+<script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+    crossorigin async
+    data-callback="initMapKit"
+    data-libraries="map,annotations"
+    data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+</script>
+
+<script type="module">
+// Wait for MapKit JS to be ready to use.
+const setupMapKitJs = async() => {
+    // If MapKit JS is not yet loaded...
+    if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+        // ...await <script>'s data-callback (window.initMapKit).
+        await new Promise(resolve => { window.initMapKit = resolve });
+        // Clean up.
+        delete window.initMapKit;
+    }
+};
+
+const main = async() => {
+    await setupMapKitJs();
+
+    // Landmarks data
+    const sanFranciscoLandmarks = [
+        {
+            coordinate: new mapkit.Coordinate(37.7951315, -122.402986),
+            title: "Transamerica Pyramid",
+            phone: "+1-415-983-5420",
+            url: "http://www.transamericapyramidcenter.com/"
+        },
+        {
+            coordinate: new mapkit.Coordinate(37.7954201, -122.39352),
+            title: "Ferry Building",
+            phone: "+1 (415) 983-8030",
+            url: "http://www.ferrybuildingmarketplace.com"
+        },
+        {
+            coordinate: new mapkit.Coordinate(37.8083396, -122.415727),
+            title: "Fisherman's Wharf",
+            phone: "+1 (415) 673-3530", url: "http://visitfishermanswharf.com"
+        },
+        {
+            coordinate: new mapkit.Coordinate(37.8023553, -122.405742),
+            title: "Coit Tower",
+            phone: "+1 (415) 249-0995",
+            url: "http://sfrecpark.org/destination/telegraph-hill-pioneer-park/coit-tower/"
+        },
+        {
+            coordinate: new mapkit.Coordinate(37.7552305, -122.452624),
+            title: "Sutro Tower",
+            phone: "+1 (415) 681-8850",
+            url: "http://www.sutrotower.com"
+        },
+        {
+            coordinate: new mapkit.Coordinate(37.779267, -122.419269),
+            title: "City Hall",
+            phone: "+1 (415) 701-2311",
+            url: "http://sfgsa.org/index.aspx?page=1085"
+        },
+        {
+            coordinate: new mapkit.Coordinate(37.8184493, -122.478409),
+            title: "Golden Gate Bridge",
+            phone: "+1 (415) 921-5858",
+            url: "http://www.goldengatebridge.org"
+        }
+    ];
+
+
+    // Callout and the associated annotation marker offset
+    const offset = new DOMPoint(-148, -58);
+
+    // Annotation (key) to annotation's landmark data (value)
+    const annotationsToLandmark = new Map();
+
+    // Annotations use these functions to present custom callouts.
+    const landmarkAnnotationCallout = {
+
+        calloutElementForAnnotation: annotation => {
+            const landmark = annotationsToLandmark.get(annotation);
+
+            const div = document.createElement("div");
+            div.className = "landmark";
+
+            const title = div.appendChild(document.createElement("h1"));
+            title.textContent = landmark.title;
+
+            const section = div.appendChild(document.createElement("section"));
+
+            const phone = section.appendChild(document.createElement("p"));
+            phone.className = "phone";
+            phone.textContent = landmark.phone;
+
+            const link = section.appendChild(document.createElement("p"));
+            link.className = "homepage";
+
+            return div;
+        },
+
+        calloutAnchorOffsetForAnnotation: (annotation, element) => offset,
+
+        calloutAppearanceAnimationForAnnotation: annotation =>
+            ".4s cubic-bezier(0.4, 0, 0, 1.5) " +
+            "0s 1 normal scale-and-fadein"
+    };
+
+    for (const landmark of sanFranciscoLandmarks) {
+        const annotation = new mapkit.MarkerAnnotation(landmark.coordinate, {
+            callout: landmarkAnnotationCallout,
+            color: "#c969e0"
+        });
+
+        annotationsToLandmark.set(annotation, landmark);
+    }
+
+    const map = new mapkit.Map("map");
+    map.showItems(Array.from(annotationsToLandmark.keys()));
+};
+
+main();
+
+</script>
+
+</head>
+
+<body>
+    <div id="map"></div>
+</body>
+</html>

--- a/Includes/details.html
+++ b/Includes/details.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+<meta charset="utf-8">
+
+<style>
+body {
+    margin: 0;
+    padding: 0;
+    background-color: rgb(255, 255, 255);
+}
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: rgb(0, 0, 0);
+    }
+}
+.container {
+    display: grid;
+    grid-template-rows: max-content 1fr;
+    width: 100%;
+    height: 600px;
+}
+.container > :first-child {
+    margin: 1rem 0;
+    justify-self: center;
+}
+.container :is(#map, #detail) {
+    display: none;
+}
+.container:has(select[value=map]) #map,
+.container:has(select[value=detail]) #detail {
+    display: block;
+    overflow: scroll;
+}
+</style>
+
+<script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+    crossorigin async
+    data-callback="initMapKit"
+    data-libraries="full-map,services"
+    data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+</script>
+
+<script type="module">
+// Wait for MapKit JS to be ready to use.
+const setupMapKitJs = async() => {
+    // If MapKit JS is not yet loaded...
+    if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+        // ...await <script>'s data-callback (window.initMapKit).
+        await new Promise(resolve => { window.initMapKit = resolve });
+        // Clean up.
+        delete window.initMapKit;
+    }
+};
+
+/**
+ * Script Entry Point
+ */
+const main = async() => {
+    await setupMapKitJs();
+
+    // Sync `<select>` `value` attribute with property value.
+    document.addEventListener("change", ev => {
+        if (ev.target?.tagName === "SELECT") {
+            ev.target.setAttribute("value", ev.target.value);
+        }
+    });
+
+    // Look up Place ID, call `annotatePlace` with results.
+    const id = "I63802885C8189B2B";
+    const lookup = new mapkit.PlaceLookup();
+    lookup.getPlace(id, annotatePlace);
+};
+
+const annotatePlace = (error, place) => {
+    // Create map.
+    const center = place.coordinate;
+    const span = new mapkit.CoordinateSpan(0.01, 0.01);
+    const region = new mapkit.CoordinateRegion(center, span);
+    const colorScheme = mapkit.Map.ColorSchemes.Adaptive;
+    const map = new mapkit.Map("map", { region, colorScheme });
+
+    // Add annotation.
+    const annotation = new mapkit.PlaceAnnotation(place);
+    map.addAnnotation(annotation);
+
+    // Tap an annotation to show details on map.
+    const accessory = new mapkit.PlaceSelectionAccessory();
+    annotation.selectionAccessory = accessory;
+
+    // Use the dropdown to view `PlaceDetail` (without map).
+    const detailElement = document.getElementById("detail");
+    const detail = new mapkit.PlaceDetail(detailElement, place, {
+        colorScheme: mapkit.PlaceDetail.ColorSchemes.Adaptive
+    });
+};
+
+main();
+
+</script>
+</head>
+
+<body>
+    <div class="container">
+        <div>
+            <select name="display" id="display" value="map">
+                <option value="map">Map</option>
+                <option value="detail">Place Detail</option>
+            </select>
+        </div>
+        <div id="map"></div>
+        <div id="detail"></div>
+    </div>
+</body>
+</html>

--- a/Includes/embeded.html
+++ b/Includes/embeded.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+        <meta charset="utf-8">
+            
+            <style>
+                #map-container {
+                    width: 100%;
+                    height: 600px;
+                }
+            </style>
+            
+            <script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+                crossorigin async
+                data-callback="initMapKit"
+                data-libraries="map"
+                data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+            </script>
+            
+            <script type="module">
+                // Wait for MapKit JS to be ready to use.
+                const setupMapKitJs = async() => {
+                    // If MapKit JS is not yet loaded...
+                    if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+                        // ...await <script>'s data-callback (window.initMapKit).
+                        await new Promise(resolve => { window.initMapKit = resolve });
+                        // Clean up.
+                        delete window.initMapKit;
+                    }
+                };
+                
+                /**
+                 * Script Entry Point
+                 */
+                const main = async() => {
+                    await setupMapKitJs();
+                    
+                    const cupertino = new mapkit.CoordinateRegion(
+                                                                  new mapkit.Coordinate(37.3316850890998, -122.030067374026),
+                                                                  new mapkit.CoordinateSpan(0.167647972, 0.354985255)
+                                                                  );
+                                                                  
+                                                                  // Create a map in the element whose ID is "map-container".
+                                                                  const map = new mapkit.Map("map-container");
+                                                                  map.region = cupertino;
+                };
+                
+                main();
+                
+            </script>
+    </head>
+    
+    <body>
+        <div id="map-container"></div>
+    </body>
+</html>
+

--- a/Includes/limits.html
+++ b/Includes/limits.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+
+<style>
+body {
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    font-family: "-apple-system-font", Futura, "Helvetica Neue", "Helvetica",
+        "Arial", "sans-serif";
+}
+
+#container {
+    width: 100%;
+    height: 600px;
+}
+
+#map-container {
+    width: 100%;
+    height: 560px;
+}
+
+#city-regions {
+    width: 100%;
+    height: 40px;
+}
+
+#city-regions > label {
+    float: left;
+    width: 50%;
+    height: 40px;
+
+    line-height: 40px;
+    text-align: center;
+    cursor: pointer;
+}
+
+#city-regions > input {
+    display: none;
+}
+
+#city-regions > input + label {
+    background-color: #fff;
+}
+
+#city-regions > input:checked + label {
+    background-color: #08f;
+    color: #f8f9f0;
+}
+
+</style>
+
+<script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+    crossorigin async
+    data-callback="initMapKit"
+    data-libraries="map"
+    data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+</script>
+
+<script type="module">
+// Wait for MapKit JS to be ready to use.
+const setupMapKitJs = async() => {
+    // If MapKit JS is not yet loaded...
+    if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+        // ...await <script>'s data-callback (window.initMapKit).
+        await new Promise(resolve => { window.initMapKit = resolve });
+        // Clean up.
+        delete window.initMapKit;
+    }
+};
+
+const domCityRegions = document.getElementById("city-regions");
+
+const main = async() => {
+    await setupMapKitJs();
+
+    // Region and Zoom variables for San Francisco and Toronto
+    const regionSanFrancisco = new mapkit.CoordinateRegion(
+        new mapkit.Coordinate(37.7812, -122.44755),
+        new mapkit.CoordinateSpan(0.10, 0.11)
+    );
+    const regionToronto = new mapkit.CoordinateRegion(
+        new mapkit.Coordinate(43.6451, -79.37505),
+        new mapkit.CoordinateSpan(0.05, 0.11)
+    );
+    const zoomRangeSanFrancisco = new mapkit.CameraZoomRange(7500, 12000);
+    const zoomRangeToronto = new mapkit.CameraZoomRange(5000, 12000);
+
+    // Create map, set the initial view to San Francisco.
+    const map = new mapkit.Map("map-container");
+    map.cameraZoomRange = zoomRangeSanFrancisco;
+    map.cameraBoundary = regionSanFrancisco.toMapRect();
+    map.center = new mapkit.Coordinate(37.7812, -122.44755);
+    map.cameraDistance = 12000;
+
+    // Current City
+    let currentCityName = "sanfrancisco";
+
+    // Define the cities.
+    const cities = {
+        sanfrancisco: {
+            selected: () => {
+                map.setCameraZoomRangeAnimated(zoomRangeSanFrancisco);
+                map.setCameraBoundaryAnimated(regionSanFrancisco.toMapRect());
+                map.setCameraDistanceAnimated(12000);
+            }
+        },
+
+        toronto: {
+            selected: () => {
+                map.setCameraZoomRangeAnimated(zoomRangeToronto);
+                map.setCameraBoundaryAnimated(regionToronto.toMapRect());
+                map.setCameraDistanceAnimated(12000);
+            }
+        }
+    }
+
+    // Listen to click events to change city.
+    domCityRegions.addEventListener("change", event => {
+        const cityName = event.target.value;
+        const cityData = cities[cityName];
+        if (currentCityName === cityName) {
+            return;
+        }
+
+        currentCityName = cityName;
+
+        cityData.selected();
+    });
+};
+
+main();
+
+</script>
+
+</head>
+<body>
+    <div id="container">
+        <div id="city-regions">
+            <input id="city-sanfrancisco" type="radio"
+                value="sanfrancisco" name="city" checked="checked" />
+            <label for="city-sanfrancisco">San Francisco</label>
+            
+            <input id="city-toronto" type="radio"
+                value="toronto" name="city" />
+            <label for="city-toronto">Toronto</label>
+        </div>
+        <div id="map-container"></div>
+    </div>
+</body>
+</html>

--- a/Includes/polylines.html
+++ b/Includes/polylines.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animated polyline</title>
+
+<style>
+
+body {
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    font-family: "-apple-system-font", Futura, "Helvetica Neue", "Helvetica",
+        "Arial", "sans-serif";
+}
+
+#map-container {
+    width: 100%;
+    height: 600px;
+}
+
+</style>
+
+<script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+    crossorigin async
+    data-callback="initMapKit"
+    data-libraries="full-map,geojson"
+    data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+</script>
+
+<script type="module">
+// Wait for MapKit JS to be ready to use.
+const setupMapKitJs = async() => {
+    // If MapKit JS is not yet loaded...
+    if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+        // ...await <script>'s data-callback (window.initMapKit).
+        await new Promise(resolve => { window.initMapKit = resolve });
+        // Clean up.
+        delete window.initMapKit;
+    }
+};
+
+const main = async() => {
+    await setupMapKitJs();
+
+    // Create a new map.
+    const map = new mapkit.Map("map-container");
+
+    const geoJsonUrl = "./sfo-oak.json";
+
+    /**
+     * Starts a request animation frame loop that increases a given `overlay`'s
+     * `strokeEnd` over a given `durationMs` time (in milliseconds).
+     */
+    const animateStroke = (overlay, durationMs) => {
+        const startTime = window.performance.now();
+
+        // Run once per frame until the animation is complete.
+        const animateStrokeEnd = timestamp => {
+            // Animation completion percentage ratio
+            const p = (timestamp - startTime) / durationMs;
+
+            // Set the `strokeEnd` to the ratio, clamped between 0 and 1.
+            overlay.style.strokeEnd = Math.max(0, Math.min(p, 1));
+
+            // If the animation isn't 100% finished, repeat in the next frame.
+            if (p < 1) {
+                window.requestAnimationFrame(animateStrokeEnd);
+            }
+        };
+
+        window.requestAnimationFrame(animateStrokeEnd);
+    };
+
+    /**
+     * Loads the route overlays from a GeoJSON file and begin the animation.
+     */
+    const showRoutes = () => {
+        mapkit.removeEventListener("configuration-change", showRoutes);
+
+        mapkit.importGeoJSON(geoJsonUrl, {
+            /**
+             * Copy the GeoJSON `title` property into the annotations to
+             * properly label the start and end annotations.
+             */
+            itemForFeature: (item, geojson) => {
+                if (geojson.properties && geojson.properties.title) {
+                    item.title = geojson.properties.title
+                }
+                return item;
+            },
+
+            /**
+             * Create a separate `mapkit.Style` for each overlay so that the
+             * animation code can independently modify each style.
+             */
+            styleForOverlay: overlay => {
+                return new mapkit.Style({
+                    lineWidth: 6,
+                    strokeOpacity: 0.5
+                });
+            },
+
+            /**
+             * Once the GeoJSON is loaded, show the loaded items and begin
+             * animating each overlay.
+             */
+            geoJSONDidComplete: function(items) {
+                map.showItems(items, {
+                    padding: new mapkit.Padding(40, 40, 40, 40)
+                });
+
+                for(const [ i, overlay ] of map.overlays.entries()) {
+                    // Initially each overlay should have 0 length.
+                    overlay.style.strokeEnd = 0;
+
+                    // Begin animation after a brief timeout.
+                    window.setTimeout(
+                        () => { animateStroke(overlay, 1700); },
+                        3000 + i * 500
+                    );
+                }
+            }
+        });
+    };
+
+    // Load the routes after the map loads (initial configuration change).
+    mapkit.addEventListener("configuration-change", showRoutes);
+};
+
+main().catch(e => { throw e; });
+
+</script>
+
+</head>
+<body>
+    <div id="map-container"></div>
+</body>
+</html>

--- a/Includes/searchFiltering.html
+++ b/Includes/searchFiltering.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+<meta charset="utf-8">
+
+<style>
+body {
+    margin: 0;
+    padding: 0;
+    background-color: rgb(255, 255, 255);
+}
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: rgb(0, 0, 0);
+    }
+}
+#map {
+    width: 100%;
+    height: 600px;
+}
+</style>
+
+<script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+    crossorigin async
+    data-callback="initMapKit"
+    data-libraries="full-map,services"
+    data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+</script>
+
+<script type="module">
+// Wait for MapKit JS to be ready to use.
+const setupMapKitJs = async() => {
+    // If MapKit JS is not yet loaded...
+    if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+        // ...await <script>'s data-callback (window.initMapKit).
+        await new Promise(resolve => { window.initMapKit = resolve });
+        // Clean up.
+        delete window.initMapKit;
+    }
+};
+
+/**
+ * Script Entry Point
+ */
+const main = async() => {
+    await setupMapKitJs();
+
+    const addressFilter = mapkit.AddressFilter.including([
+        mapkit.AddressCategory.Locality
+    ]);
+    const citySearch = new mapkit.Search({ addressFilter });
+    citySearch.search("Cupertino", showMap);
+};
+
+const showMap = (error, cities) => {
+    // Draw a map centered on the city.
+    const center = cities.places[0].coordinate;
+    const span = new mapkit.CoordinateSpan(0.02, 0.02);
+    const region = new mapkit.CoordinateRegion(center, span);
+    const map = new mapkit.Map("map", { region });
+
+    const searchSpan = new mapkit.CoordinateSpan(0.01, 0.01);
+    const searchRegion = new mapkit.CoordinateRegion(center, span);
+
+    // Draw an overlay (visually represent search bounds).
+    const minX = center.longitude - searchSpan.longitudeDelta;
+    const maxX = center.longitude + searchSpan.longitudeDelta;
+    const minY = center.latitude - searchSpan.latitudeDelta;
+    const maxY = center.latitude + searchSpan.latitudeDelta;
+    const points = [
+        new mapkit.Coordinate(minY, minX),
+        new mapkit.Coordinate(minY, maxX),
+        new mapkit.Coordinate(maxY, maxX),
+        new mapkit.Coordinate(maxY, minX)
+    ];
+    const style = new mapkit.Style({
+        lineWidth: 2,
+        strokeColor: "#FF0000",
+        fillColor: null
+    });
+    map.addOverlay(new mapkit.PolygonOverlay(points, { style }));
+
+    // Search for coffee in `searchRegion`.
+    const coffeeSearch = new mapkit.Search({
+        region: searchRegion,
+        regionPriority: mapkit.Search.RegionPriority.Required
+    });
+    coffeeSearch.search("coffee", (error, results) => {
+        for (const place of results.places) {
+            const marker = new mapkit.PlaceAnnotation(place);
+            map.addAnnotation(marker);
+        }
+    });
+};
+
+main();
+
+</script>
+</head>
+
+<body>
+    <div id="map"></div>
+</body>
+</html>

--- a/Includes/usPop.html
+++ b/Includes/usPop.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html>
+    <head>
+<title>US Population By State Overlays</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, user-scalable=no">
+
+<style>
+
+body {
+    font-family: "Helvetica Neue", sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    position: relative;
+}
+
+#map {
+    width: 100%;
+    height: 100%;
+}
+
+#infoPopup {
+    display: none;
+    top: 7px;
+    left: 67px;
+    background: #FFFFFF;
+    padding: 5px 15px;
+    position: absolute;
+    z-index: 1000;
+    min-width:180px;
+    font: 13px/16px "-apple-system-font" ,"HelveticaNeue-Medium", "Helvetica", "Arial", "sans-serif";
+    color: #212121;
+    border: 1px solid rgba(0,0,0,0.2);
+    border-radius: 3px;
+}
+
+.container .map-legend {
+    position: absolute;
+    z-index: 1000;
+    top: 7px;
+    left: 7px;
+}
+
+.map-legend div {
+    margin-bottom: 5px;
+    width: 40px;
+    font-size: 12px;
+    color: #fff;
+    padding: 4px 7px;
+}
+
+#infoPopup .info {
+    padding: 10px 0;
+    box-sizing: border-box;
+}
+
+#infoPopup .info:first-child {
+    border-bottom: 1px solid rgba(0,0,0,0.2);
+}
+
+#infoPopup .info-country,  #infoPopup .info-population{
+    margin-left: 5px;
+    color: #464545;
+    font-style: italic;
+}
+
+</style>
+
+<script src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+    crossorigin async
+    data-callback="initMapKit"
+    data-libraries="map,overlays"
+    data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+</script>
+
+<script type="module">
+// Wait for MapKit JS to be ready to use.
+const setupMapKitJs = async() => {
+    // If MapKit JS is not yet loaded...
+    if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+        // ...await <script>'s data-callback (window.initMapKit).
+        await new Promise(resolve => { window.initMapKit = resolve });
+        // Clean up.
+        delete window.initMapKit;
+    }
+};
+
+const main = async() => {
+    await setupMapKitJs();
+
+    const LINE_WIDTH_DEFAULT = 0.5;
+    const LINE_WIDTH_SELECTED = 3;
+    const POPULATION_BUCKETS = [
+        {
+            color: "#e4dedb",
+            range: "< 50K",
+            num: 50000
+        },
+        {
+            color: "#fde0dd",
+            range: "50K +",
+            num: 500000
+        },
+        {
+            color: "#fcc5c0",
+            range: "500K +",
+            num: 1000000
+        },
+        {
+            color: "#fa9fb5",
+            range: "1M +",
+            num: 5000000
+        },
+        {
+            color: "#f768a1",
+            range: "5M +",
+            num: 10000000
+        },
+        {
+            color: "#dd3497",
+            range: "10M +",
+            num: 20000000
+        },
+        {
+            color: "#ae017e",
+            range: "20M +",
+            num: 30000000
+        },
+        {
+            color: "#7a0177",
+            range: "> 30M",
+            num: Infinity
+        }
+    ];
+
+    const northAmericaCenter = new mapkit.Coordinate(39.622, -98.606);
+    const map = new mapkit.Map("map", { center: northAmericaCenter });
+
+    // Add the population legend (color-rectangles in the top left).
+    const mapLegend = document.querySelector(".map-legend");
+
+    for (const bucket of POPULATION_BUCKETS) {
+        const el = document.createElement("div");
+        const textNode = document.createTextNode(bucket.range);
+        el.appendChild(textNode);
+        el.style.background = bucket.color;
+        mapLegend.appendChild(el);
+    }
+
+    // Read the GeoJSON, setting the color for each overlay as it is parsed.
+    mapkit.importGeoJSON("states.json", {
+
+        // Convert MultiPolygon states into concatenated PolygonOverlays.
+        itemForMultiPolygon: (collection, geoJSON) => {
+            const points = collection.getFlattenedItemList().reduce(
+                (points, overlay) => points.concat(overlay.points),
+                []
+            );
+            return new mapkit.PolygonOverlay(points);
+        },
+
+        // Add colors to each finalized overlay based on the data.
+        itemForFeature: (overlay, geoJSON) => {
+            const name = geoJSON.properties.name;
+            const population = geoJSON.properties.population;
+
+            // Add data to the overlay to be shown when it is selected.
+            overlay.data = { name, population };
+
+            // Find the right color for the population and the set the style.
+            for (const bucket of POPULATION_BUCKETS) {
+                if (population < bucket.num) {
+                    overlay.style = new mapkit.Style({
+                        fillOpacity: 0.7,
+                        lineWidth: LINE_WIDTH_DEFAULT,
+                        fillColor: bucket.color
+                    });
+                    break;
+                }
+            }
+
+            return overlay;
+        },
+
+        // When all the data has been imported, we can show the results.
+        geoJSONDidComplete: overlays => {
+            map.showItems(overlays);
+        }
+    });
+
+    // Set up user-interaction (show data when an overlay is selected).
+    const infoPopup = document.getElementById("infoPopup");
+    const infoCountry = infoPopup.querySelector(".info-country");
+    const infoPopulation = infoPopup.querySelector(".info-population");
+
+    // Update the informative DOM element to describe the given data.
+    const showInfo = data => {
+        infoCountry.innerText = data.name;
+        infoPopulation.innerText = data.population.toLocaleString();
+        infoPopup.style.display = "block";
+    };
+
+    // Hide the informative DOM element.
+    const closeInfo = () => {
+        infoPopup.style.display = "none";
+    };
+
+    map.addEventListener("select", event => {
+        if (event.overlay && event.overlay.data) {
+            event.overlay.style.lineWidth = LINE_WIDTH_SELECTED;
+            showInfo(event.overlay.data);
+        }
+    });
+
+    map.addEventListener("deselect", event => {
+        if (event.overlay) {
+            event.overlay.style.lineWidth = LINE_WIDTH_DEFAULT;
+            closeInfo();
+        }
+    });
+
+};
+
+main();
+
+</script>
+
+</head>
+<body>
+    <div class="container">
+        <div id="map"></div>
+        <div id="infoPopup">
+            <div class="info">
+                <span>State:</span>
+                <span class="info-country"></span>
+            </div>
+            <div class="info">
+                <span>Population:</span>
+                <span class="info-population"></span>
+            </div>
+        </div>
+        <div class="map-legend"></div>
+    </div>
+</body>
+</html>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,7 @@ let package = Package(
     name: "IgniteSamples",
     platforms: [.macOS(.v13)],
     dependencies: [
-        .package(url: "https://github.com/twostraws/Ignite.git", branch: "main")
+        .package(url: "https://github.com/dl-alexandre/Ignite", branch: "main")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/Pages/Examples/MapExamples.swift
+++ b/Sources/Pages/Examples/MapExamples.swift
@@ -1,0 +1,148 @@
+//
+// MapExamples.swift
+// IgniteSamples
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+import Ignite
+
+struct MapExamples: StaticPage {
+    var title = "Maps"
+
+    func body(context: PublishingContext) async -> [BlockElement] {
+        Script(code: """
+        src="https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js"
+               crossorigin async
+               data-callback="initMapKit"
+               data-libraries="map"
+               data-token="eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw">
+        
+        """)
+        
+        Script(code: """
+        // Wait for MapKit JS to be ready to use.
+        const setupMapKitJs = async() => {
+        // If MapKit JS is not yet loaded...
+        if (!window.mapkit || window.mapkit.loadedLibraries.length === 0) {
+        // ...await <script>'s data-callback (window.initMapKit).
+        await new Promise(resolve => { window.initMapKit = resolve });
+        // Clean up.
+        delete window.initMapKit;
+        }
+        };
+        
+        const main = async() => {
+        await setupMapKitJs();
+        
+        // Create the Map and Geocoder.
+        const map = new mapkit.Map("map-container");
+        const geocoder = new mapkit.Geocoder({ language: "en-US" });
+        
+        // Create the "Event" annotation, setting properties in the constructor.
+        const event = new mapkit.Coordinate(37.7831, -122.4041);
+        const eventAnnotation = new mapkit.MarkerAnnotation(event, {
+        color: "#4eabe9",
+        title: "Event",
+        glyphText: "\u{1F37F}" // Popcorn Emoji
+        });
+        
+        // Create the "Work" annotation, setting properties after construction.
+        const work = new mapkit.Coordinate(37.3349, -122.0090);
+        const workAnnotation = new mapkit.MarkerAnnotation(work);
+        workAnnotation.color = "#969696";
+        workAnnotation.title = "Work";
+        workAnnotation.subtitle = "Apple Park";
+        workAnnotation.selected = "true";
+        workAnnotation.glyphText = "\u{F8FF}"; // Apple Symbol
+        
+        // Add and show both annotations on the map.
+        map.showItems([eventAnnotation, workAnnotation]);
+        
+        // This contains the user-set single-tap annotation.
+        let clickAnnotation = null;
+        
+        // Add or move an annotation when a user single-taps an empty space.
+        map.addEventListener("single-tap", event => {
+        if (clickAnnotation) {
+            map.removeAnnotation(clickAnnotation);
+        }
+        
+        // Get the clicked coordinate and add an annotation there.
+        const point = event.pointOnPage;
+        const coordinate = map.convertPointOnPageToCoordinate(point);
+        
+        clickAnnotation = new mapkit.MarkerAnnotation(coordinate, {
+            title: "Loading...",
+            color: "#c969e0"
+        });
+        
+        map.addAnnotation(clickAnnotation);
+        
+        // Look up the address with the Geocoder's Reverse Lookup Function.
+        geocoder.reverseLookup(coordinate, (error, data) => {
+            const first = (!error && data.results) ? data.results[0] : null;
+            clickAnnotation.title = (first && first.name) || "";
+        });
+        });
+        
+        };
+        
+        main();
+        """).addCustomAttribute(name: "type", value: "module")
+        
+        
+        Text("Maps")
+            .font(.title1)
+
+        Text("Maps let you place map content onto your page")
+            .font(.lead)
+
+        Alert {
+            Text(markdown: "**Important:** Always attach an `aspectRatio()` modifier to embeds, so they scale correctly.")
+        }
+        .role(.warning)
+
+        Text("For example, here's a YouTube video:")
+
+        CodeBlock(language: "swift", """
+        Embed(youTubeID: "dQw4w9WgXcQ", title: "There was only ever going to be one video used here.")
+            .aspectRatio(.r16x9)
+        """)
+
+        
+            .aspectRatio(.r16x9)
+            .margin(.bottom, .extraLarge)
+        
+//        Include("embeded.html")
+        
+//        Include("annotations.html")
+        
+//        Include("calloutAccessory.html")
+        
+//        Include("customCallout.html")
+        
+//        Include("details.html") // messes up whole page
+        
+//        Include("limits.html")
+        
+//        Include("searchFiltering.html")
+        
+//        Include("polylines.html") // works but needs polyline
+ 
+        
+//        Include("usPop.html") // works but needs data
+        
+
+        Text("here's a Map of The Family Farm")
+
+        CodeBlock(language: "swift", """
+        Map(title: "My Map", url: "https://embed.apple-mapkit.com/v1/place?place=I2FEB0F2FB4D7B0EE&token=eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw")
+            .aspectRatio(.r16x9)
+        """)
+
+        Map(title: "My Map", url: "https://embed.apple-mapkit.com/v1/place?place=I2FEB0F2FB4D7B0EE&token=eyJraWQiOiJSNzgzRjNIOE05IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiIyTVA4UVdLN1I2IiwiaWF0IjoxNzIxODU1OTU0LCJleHAiOjE3MjI0OTU1OTl9.ViD505SG9QW54fv5h3iv9lQsY328OlHF-1mEPdFeNzRmqrRI137IaXlGXr2W5lR9brWG7Luej1SoEyr8beXsjw")
+            .aspectRatio(.r16x9)
+    }
+}

--- a/Sources/Pages/Home.swift
+++ b/Sources/Pages/Home.swift
@@ -50,6 +50,7 @@ struct Home: StaticPage {
             Link("Includes", target: IncludeExamples())
             Link("Links", target: LinkExamples())
             Link("Lists", target: ListExamples())
+            Link("Maps", target: MapExamples())
             Link("Quotes", target: QuoteExamples())
             Link("Tables", target: TableExamples())
         }

--- a/Sources/Site.swift
+++ b/Sources/Site.swift
@@ -17,7 +17,7 @@ struct IgniteWebsite {
 struct ExampleSite: Site {
     var name = "My Awesome Site"
     var titleSuffix = " – My Awesome Site"
-    var url = URL("https://www.yoursite.com")
+    var url: URL = URL("https://www.example.com")
 
     var builtInIconsEnabled = true
     var syntaxHighlighters = [SyntaxHighlighter.swift, .python, .ruby]
@@ -48,6 +48,7 @@ struct ExampleSite: Site {
         IncludeExamples()
         LinkExamples()
         ListExamples()
+        MapExamples()
         QuoteExamples()
         StylingExamples()
         TableExamples()


### PR DESCRIPTION
Hi Mr. Hudson,

Mostly curious with how MapKit JS could be used in an Ignite Site. Using `Include` [MapKit JS Sample-Code](https://developer.apple.com/maps/sample-code/) displays on any page. Do you have an idea or suggestion of better implementation via an element(s)?  

Possible variables a Map Element could have:
- Apple's MapKit JS Token *required
- Region
    - Coordinate
    - Span
- Camera
    - Zoom
    - Boundary
    - Center
    - Distance 
- Search
- Annotations
- Libraries
    - Map
        - Full-Map 
    - Annotations 
    - Services
    - Overlays
    - Geojson 


Initial Map Element Sample which works with [Web Embed](https://developer.apple.com/maps/create-a-map/)

```swift
//
// Map.swift
// Ignite
// https://www.github.com/twostraws/Ignite
// See LICENSE for license information.
//

import Foundation

/// Embeds a MapKit JS map.
public struct Map: BlockElement, LazyLoadable {
    /// The standard set of control attributes for HTML elements.
    public var attributes = CoreAttributes()
    
    /// How many columns this should occupy when placed in a section.
    public var columnWidth = ColumnWidth.automatic
    
    /// The URL for the MapKit JS map.
    let url: String
    
    /// A title that describes this content.
    let title: String
    
    /// Creates a new `Map` instance from the title and URL provided.
    /// - Parameters:
    ///   - title: A title suitable for screen readers.
    ///   - url: The URL to embed on your page.
    public init(title: String, url: URL) {
        self.url = url.absoluteString
        self.title = title
    }
    
    /// Creates a new `Map` instance from the title and URL provided.
    /// - Parameters:
    ///   - title: A title suitable for screen readers.
    ///   - url: The URL to embed on your page.
    public init(title: String, url: String) {
        self.url = url
        self.title = title
    }
    
    /// Renders this element using the publishing context passed in.
    /// - Parameter context: The current publishing context.
    /// - Returns: The HTML for this element.
    public func render(context: PublishingContext) -> String {
        // Permissions for the iframe.
        let allowPermissions = """
            accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share
            """
        
        if attributes.classes.contains("ratio") == false {
            context.addWarning("""
            Embedding \(url) without an aspect ratio will cause it to appear very small. \
            It is recommended to use aspectRatio() so it can scale automatically.
            """)
        }
        
        return Group {
            #"<iframe src="\#(url)" title="\#(title)" allow="\#(allowPermissions)" style="width: 100%; height: 100%; border: none;"></iframe>"#
        }
        .attributes(attributes)
        .render(context: context)
    }
}
```

Stipulation: **Tokens require Developer Accounts**

Warning: **Running multiple `Include`s overrides previous `Include`s styling effect page formatting** `Include`s run individually unless otherwise noted. (e.g. Missing Polyline.js)