### PR TITLE
`.target(.blank)' Example

### DIFF
--- a/Sources/Pages/Examples/LinkExamples.swift
+++ b/Sources/Pages/Examples/LinkExamples.swift
@@ -42,6 +42,20 @@ struct LinkExamples: StaticPage {
             Link("Learn about carousels", target: CarouselExamples())
         }
 
+        Text("Using a `.target(.blank)` modifier opens new tabs")
+
+        CodeBlock(language: "swift", """
+        Text {
+            Link("Another tab of links", target: LinkExamples())
+                .target(.blank)
+        }
+        """)
+
+        Text {
+            Link("Another tab of links", target: LinkExamples())
+                .target(.blank)
+        }
+
         Alert {
             Text(markdown: "**Tip:** Page targets use initialized pages, so you can pass in custom values that adjust the path.")
         }


### PR DESCRIPTION
[Issue 109](https://github.com/twostraws/Ignite/issues/109) explains confusion regarding link opening new tabs. ExampleSite update better displays .target(.blank) capabilities.