### PR TITLE
Use Reserved Domains

### DIFF
--- a/Sources/Site.swift
+++ b/Sources/Site.swift
@@ -17,13 +17,14 @@ struct IgniteWebsite {
 struct ExampleSite: Site {
     var name = "My Awesome Site"
     var titleSuffix = " – My Awesome Site"
-    var url = URL(static: "https://www.yoursite.com")
+    var url = URL(static: "https://www.example.com")
 
     var builtInIconsEnabled = true
     var syntaxHighlighterConfiguration: SyntaxHighlighterConfiguration = .init(languages: [.swift, .python, .ruby])
-    var feedConfiguration = FeedConfiguration(mode: .full, contentCount: 20, image: .init(url: "https://www.yoursite.com/images/icon32.png", width: 32, height: 32))
+    var feedConfiguration = FeedConfiguration(mode: .full, contentCount: 20, image: .init(url: "https://www.example.com/images/icon32.png", width: 32, height: 32))
     var robotsConfiguration = Robots()
     var author = "Paul Hudson"
+    var useDefaultBootstrapURLs: BootstrapOptions { .remoteBootstrap }
 
     var homePage = Home()
     var tagPage = Tags()


### PR DESCRIPTION
`example.com` is a reserved domain([rfc2606][]) by the IANA, and is recommended to use for documentation and examples([rfc6761][]).

I think it would be better to replace the current domain that's descriptive but privately owned, to a domain that's officially reserved for documentation purpose.

# Alternatives Considered

While it's possible to add a subdomain like `yoursite.example.com`, but considering `example.com` status as an official reserved domain and used though out the industry and is also used with in the Ignite project for documentation and tests, I think the using the standard `www.example.com` would be enough for most people to indicate it's use as an placeholder.

[rfc2606]: https://www.rfc-editor.org/rfc/rfc2606.html
[rfc6761]: https://www.rfc-editor.org/rfc/rfc6761.html