### PR TITLE
New LiveExample macro for documentation.

### DIFF
--- a/MacroSources/LiveExampleMacro.swift
+++ b/MacroSources/LiveExampleMacro.swift
@@ -1,0 +1,83 @@
+//
+// LiveExampleMacro.swift
+// IgniteSamples
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Foundation
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum LiveExampleMacro: ExpressionMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        guard let closure = node.trailingClosure else {
+            throw LiveExampleMacroError.missingTrailingClosure
+        }
+
+        let source = normalizedSource(from: closure.statements.description)
+        let previewMargin = node.arguments.first { $0.label?.text == "previewMargin" }?.expression
+
+        if let previewMargin {
+            return """
+            RenderedCodeExample(source: \(literal: source), previewMargin: \(previewMargin)) \(raw: closure.description)
+            """
+        }
+
+        return """
+        RenderedCodeExample(source: \(literal: source)) \(raw: closure.description)
+        """
+    }
+
+    private static func normalizedSource(from source: String) -> String {
+        var lines = source.components(separatedBy: .newlines)
+
+        while lines.first?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+            lines.removeFirst()
+        }
+
+        while lines.last?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+            lines.removeLast()
+        }
+
+        let minimumIndentation = lines
+            .filter { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
+            .map(indentationWidth)
+            .min() ?? 0
+
+        return lines
+            .map { removeIndentation(minimumIndentation, from: $0) }
+            .joined(separator: "\n")
+    }
+
+    private static func indentationWidth(of line: String) -> Int {
+        line.prefix { $0 == " " || $0 == "\t" }.count
+    }
+
+    private static func removeIndentation(_ indentation: Int, from line: String) -> String {
+        let width = min(indentation, indentationWidth(of: line))
+        return String(line.dropFirst(width))
+    }
+}
+
+private enum LiveExampleMacroError: Error, CustomStringConvertible {
+    case missingTrailingClosure
+
+    var description: String {
+        switch self {
+        case .missingTrailingClosure:
+            "#LiveExample requires a trailing closure containing the Swift code to render and run."
+        }
+    }
+}
+
+@main
+struct IgniteSampleMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        LiveExampleMacro.self
+    ]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "IgniteSamples",
@@ -9,19 +10,32 @@ let package = Package(
     dependencies: [
         // The line below makes Ignite Samples use
         // the main Ignite repository.
-        .package(url: "https://github.com/twostraws/Ignite.git", branch: "main")
+        .package(url: "https://github.com/twostraws/Ignite.git", branch: "main"),
 
         // This line makes Ignite Samples use a local
         // copy of Ignite, placed one folder up
         // from Ignite Samples, which is helpful when
         // trying things out locally.
-        // .package(path: "../Ignite")
+        // .package(path: "../Ignite"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0-latest")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
+        .macro(
+            name: "IgniteSampleMacrosImplementation",
+            dependencies: [
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax")
+            ],
+            path: "MacroSources"
+        ),
         .executableTarget(
             name: "IgniteSamples",
-            dependencies: ["Ignite"]),
+            dependencies: [
+                "Ignite",
+                "IgniteSampleMacrosImplementation"
+            ],
+            path: "Sources"),
     ]
 )

--- a/Sources/Components/LiveExample.swift
+++ b/Sources/Components/LiveExample.swift
@@ -1,0 +1,49 @@
+//
+// LiveExample.swift
+// IgniteSamples
+// https://www.github.com/twostraws/Ignite
+// See LICENSE for license information.
+//
+
+import Ignite
+
+/// Renders a Swift code example followed by the result of running that same code.
+///
+/// - Important: This file is designed specifically for Ignite Samples. Without it,
+/// every code sample would need to be written twice: once as a string for display,
+/// and once as Swift code to run. Unless we're very careful, that creates drift as
+/// the API changes. Although this macro might be useful in other projects, it is not
+/// required in regular Ignite sites.
+@freestanding(expression)
+macro LiveExample<Content: HTML>(
+    previewMargin: SpacingAmount? = nil,
+    @HTMLBuilder _ content: () -> Content
+) -> RenderedCodeExample<Content> = #externalMacro(
+    module: "IgniteSampleMacrosImplementation",
+    type: "LiveExampleMacro"
+)
+
+/// A Swift code example that is rendered from the same source used to produce its preview.
+struct RenderedCodeExample<Content: HTML>: HTML {
+    private let source: String
+    private let previewMargin: SpacingAmount?
+    private let content: Content
+
+    var body: some HTML {
+        CodeBlock(.swift) {
+            source
+        }
+
+        if let previewMargin {
+            content.margin(.bottom, previewMargin)
+        } else {
+            content
+        }
+    }
+
+    init(source: String, previewMargin: SpacingAmount? = nil, @HTMLBuilder content: () -> Content) {
+        self.source = source
+        self.previewMargin = previewMargin
+        self.content = content()
+    }
+}

--- a/Sources/Pages/Examples/ListExamples.swift
+++ b/Sources/Pages/Examples/ListExamples.swift
@@ -25,100 +25,55 @@ struct ListExamples: StaticPage {
 
             Text("A simple list can be made up just of hard-coded strings, like this:")
 
-            CodeBlock(.swift) {
-                """
+            #LiveExample(previewMargin: .xLarge) {
                 List {
                     "This is a list item"
                     "So is this"
                     "And this"
                 }
-                """
             }
-
-            List {
-                "This is a list item"
-                "So is this"
-                "And this"
-            }
-            .margin(.bottom, .xLarge)
 
             Text(markdown: "Alternatively, you can pass in an array like this:")
 
-            CodeBlock(.swift) {
-                """
+            #LiveExample(previewMargin: .xLarge) {
                 List(User.examples) { user in
                     user.name
                 }
-                """
             }
-
-            List(User.examples) { user in
-                user.name
-            }
-            .margin(.bottom, .xLarge)
 
             Text(markdown: "Lists are unordered by default. Use the `listMarkerStyle()` modifier to change that:")
 
-            CodeBlock(.swift) {
-                """
+            #LiveExample(previewMargin: .xLarge) {
                 List {
                     "This is the first list item"
                     "This is the second one"
                     "And here's one more"
                 }
                 .listMarkerStyle(.ordered(.automatic))
-                """
             }
         }
 
-        List {
-            "This is the first list item"
-            "This is the second one"
-            "And here's one more"
-        }
-        .listMarkerStyle(.ordered(.automatic))
-        .margin(.bottom, .xLarge)
-
         Text("You can customize the bullet style by adjusting the list marker style. For example, here are Roman numerals:")
 
-        CodeBlock(.swift) {
-            """
+        #LiveExample(previewMargin: .xLarge) {
             List {
                 "Veni"
                 "Vidi"
                 "Vici"
             }
             .listMarkerStyle(.ordered(.lowerRoman))
-            """
         }
-
-        List {
-            "Veni"
-            "Vidi"
-            "Vici"
-        }
-        .listMarkerStyle(.ordered(.lowerRoman))
-        .margin(.bottom, .xLarge)
 
         Text("And here is a custom style using emoji:")
 
-        CodeBlock(.swift) {
-            """
+        #LiveExample {
             List {
                 "The players gonna play"
                 "Haters gonna hate"
                 "Fakers gonna fake"
             }
             .listMarkerStyle(.custom("💃"))
-            """
         }
-
-        List {
-            "The players gonna play"
-            "Haters gonna hate"
-            "Fakers gonna fake"
-        }
-        .listMarkerStyle(.custom("💃"))
 
         Text("List Styles")
             .font(.title2)
@@ -126,73 +81,37 @@ struct ListExamples: StaticPage {
 
         Text(markdown: "Lists can be styled in different ways using the `listStyle()` modifier:")
 
-        CodeBlock(.swift) {
-            """
+        #LiveExample(previewMargin: .medium) {
             List {
                 "Default list item"
                 "Another default item"
             }
-            """
         }
 
-        List {
-            "Default list item"
-            "Another default item"
-        }
-        .margin(.bottom, .medium)
-
-        CodeBlock(.swift) {
-            """
+        #LiveExample(previewMargin: .xLarge) {
             List {
                 "Plain list item"
                 "Another plain list item"
             }
             .listStyle(.plain)
-            """
         }
 
-        List {
-            "Plain list item"
-            "Another plain list item"
-        }
-        .listStyle(.plain)
-        .margin(.bottom, .xLarge)
-
-        CodeBlock(.swift) {
-            """
+        #LiveExample(previewMargin: .medium) {
             List {
                 "Group list item"
                 "Another group item"
                     .badge(Badge("1").role(.primary))
             }
             .listStyle(.group)
-            """
         }
 
-        List {
-            "Group list item"
-            "Another group item"
-                .badge(Badge("1").role(.primary))
-        }
-        .listStyle(.group)
-        .margin(.bottom, .medium)
-
-        CodeBlock(.swift) {
-            """
+        #LiveExample(previewMargin: .xLarge) {
             List {
                 "Horizontal group item"
                 "Another horizontal item"
             }
             .listStyle(.horizontalGroup)
-            """
         }
-
-        List {
-            "Horizontal group item"
-            "Another Horizontal item"
-        }
-        .listStyle(.horizontalGroup)
-        .margin(.bottom, .xLarge)
 
         Text("List Items")
             .font(.title2)
@@ -200,27 +119,16 @@ struct ListExamples: StaticPage {
 
         Text(markdown: "When using `List` with `listStyle(.group)`, you can add roles via `ListItem`:")
 
-        CodeBlock(.swift) {
-            """
+        #LiveExample(previewMargin: .xLarge) {
             List {
                 ForEach(Role.standardRoles) { role in
-                    ListItem { 
-                        "A simple \\(role.rawValue) list group item" 
+                    ListItem {
+                        "A simple \(role.rawValue) list group item"
                     }
                     .role(role)
                 }
             }
             .listStyle(.group)
-            """
         }
-
-        List {
-            ForEach(Role.standardRoles) { role in
-                ListItem { "A simple \(role.rawValue) list group item" }
-                    .role(role)
-            }
-        }
-        .listStyle(.group)
-        .margin(.bottom, .xLarge)
     }
 }


### PR DESCRIPTION
#47 highlighted a problem in the documentation, which is that some stringified sample code had drifted from the code used to generate it. I found at least one other example of this problem here ([string](https://github.com/twostraws/IgniteSamples/blob/9d6c34e347fe0c424c1485359f587e2bd3657046/Sources/Pages/Examples/AlertExamples.swift#L47) and [code](https://github.com/twostraws/IgniteSamples/blob/9d6c34e347fe0c424c1485359f587e2bd3657046/Sources/Pages/Examples/AlertExamples.swift#L56)), and I suspect there are more.

This PR introduces Swift macros as a possible solution. It adds a new freestanding expression macro called `#LiveExample`, which executes Swift code as normal but also provides the string form of it for documentation purposes. I have converted `ListExamples` to use the new macro so you can try it yourself, but we could probably get an AI agent to convert the rest for us if the consensus is positive.